### PR TITLE
Adding alternate composition

### DIFF
--- a/Subnet.lw
+++ b/Subnet.lw
@@ -7,7 +7,7 @@ import Fugue.AWS.EC2 as EC2
 
 # Insert the AWS ID of an existing VPC below, or replace this value
 # with a new Fugue.AWS.EC2.Vpc value.
-existingVpc: EC2.Vpc.external("vpc-1234abcd", AWS.Us-west-2)
+exampleVpc: EC2.Vpc.external("vpc-1234abcd", AWS.Us-west-2)
 
 #########################
 # NETWORKS
@@ -15,5 +15,17 @@ existingVpc: EC2.Vpc.external("vpc-1234abcd", AWS.Us-west-2)
 
 public-10-0-1-0: EC2.Subnet.new {
   cidrBlock: '10.0.1.0/24',
-  vpc: existingVpc
+  vpc: exampleVpc
+}
+
+# Same behavior as the default ACL for the VPC, but explicit in the Ludwig.
+myDefaultAcl: EC2.NetworkAcl.new {
+  vpc: exampleVpc,
+  entries: [
+    # Allows inbound HTTP traffic from anywhere.
+    EC2.NetworkAcl.Entry.allowInboundPorts {ruleNumber: 100, protocol: EC2.Protocol.All, from: 0, to: 65535},
+    # Allows outbound HTTP traffic to anywhere.
+    EC2.NetworkAcl.Entry.allowOutboundPorts {ruleNumber: 100, protocol: EC2.Protocol.All, from: 0, to: 65535},
+  ],
+  associations: [public-10-0-1-0],
 }

--- a/SubnetAndVpc.lw
+++ b/SubnetAndVpc.lw
@@ -1,0 +1,20 @@
+# This example composition creates a subnet inside a new VPC.
+
+composition
+
+import Fugue.AWS as AWS
+import Fugue.AWS.EC2 as EC2
+
+#########################
+# NETWORKS
+#########################
+
+public-10-0-1-0: EC2.Subnet.new {
+  cidrBlock: '10.0.1.0/24',
+  vpc: exampleVpc
+}
+
+exampleVpc: EC2.Vpc.new {
+  cidrBlock: "10.0.0.0/16",
+  region: AWS.Us-west-2,
+}


### PR DESCRIPTION
This makes it so that users can run one composition if they want to create a subnet inside an _external_ VPC and another composition if they want to create a subnet inside a _new_ VPC.